### PR TITLE
Digraph render method raising OSError on Mac OS X

### DIFF
--- a/graphviz/files.py
+++ b/graphviz/files.py
@@ -106,7 +106,7 @@ class File(Base):
 
         params = {'engine': self._engine, 'format': self._format, 'filepath': filepath}
         cmd = self._cmd % params
-        returncode = subprocess.Popen(cmd).wait()
+        returncode = subprocess.Popen(cmd.split()).wait()
 
         rendered = '%s.%s' % (filepath, self._format)
 


### PR DESCRIPTION
I am unable to run the Round Table example from the repository homepage on a device running Mac OS X. The `render` step goes as follows:

``` python
>>> dot.render('round-table.gv', view=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "graphviz/files.py", line 109, in render
    returncode = subprocess.Popen(cmd).wait()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1308, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

The cause, in my case, is that the `cmd` argument passed to `Popen` is a single string that contains command-line arguments. It ends up that the `Popen` `args` argument has different behavior on Windows versus UNIX. From the [documentation](http://docs.python.org/2/library/subprocess.html#subprocess.Popen):

> On Unix, if args is a string, the string is interpreted as the name or path of the program to execute. However, this can only be done if not passing arguments to the program.

Further down:

> On Windows, if args is a sequence, it will be converted to a string in a manner described in Converting an argument sequence to a string on Windows. This is because the underlying CreateProcess() operates on strings.

This commit fixed it for me. As I understand the documentation, I think it will be fine on Windows, too, but I am not able to easily test it out right now.
