### PR TITLE
fix view methods on Linux and Darwin

### DIFF
--- a/graphviz/files.py
+++ b/graphviz/files.py
@@ -254,7 +254,7 @@ class File(Base):
     @staticmethod
     def _view_linux2(filepath):
         """Open filepath in the user's preferred application (linux)."""
-        subprocess.Popen(['xdg-open', filepath], shell=True)
+        subprocess.Popen(['xdg-open', filepath])
 
     @staticmethod
     def _view_win32(filepath):
@@ -264,7 +264,7 @@ class File(Base):
     @staticmethod
     def _view_darwin(filepath):
         """Open filepath with its default application (mac)."""
-        subprocess.Popen(['open', filepath], shell=True)
+        subprocess.Popen(['open', filepath])
 
 
 class Source(File):


### PR DESCRIPTION
It doesn't work with shell=True and is a security problem anyway.
Calling with the python list of strings is sufficient and works.