### PR TITLE
adding _repr_svg_ to Source

### DIFF
--- a/graphviz/dot.py
+++ b/graphviz/dot.py
@@ -87,9 +87,6 @@ class Dot(files.File):
 
     source = property(__str__, doc='The DOT source code as string.')
 
-    def _repr_svg_(self):
-        return self.pipe(format='svg').decode(self._encoding)
-
     def node(self, name, label=None, _attributes=None, **attrs):
         """Create a node.
 

--- a/graphviz/files.py
+++ b/graphviz/files.py
@@ -286,3 +286,6 @@ class Source(File):
     def __init__(self, source, filename=None, directory=None, format=None, engine=None, encoding=None):
         super(Source, self).__init__(filename, directory, format, engine, encoding)
         self.source = source
+
+    def _repr_svg_(self):
+        return self.pipe(format='svg').decode(self._encoding)

--- a/graphviz/files.py
+++ b/graphviz/files.py
@@ -132,6 +132,9 @@ class File(Base):
         if encoding is not None:
             self.encoding = encoding
 
+    def _repr_svg_(self):
+        return self.pipe(format='svg').decode(self._encoding)
+
     def pipe(self, format=None):
         """Return the source piped through the Graphviz layout command.
 
@@ -286,6 +289,3 @@ class Source(File):
     def __init__(self, source, filename=None, directory=None, format=None, engine=None, encoding=None):
         super(Source, self).__init__(filename, directory, format, engine, encoding)
         self.source = source
-
-    def _repr_svg_(self):
-        return self.pipe(format='svg').decode(self._encoding)


### PR DESCRIPTION
I extended Source class to possess _repr_svg_ method.
Now it can be rendered in Jupyter Notebooks like Dot or Digraph class.