### PR TITLE
Resolve tools class path import issue

### DIFF
--- a/graphviz/backend.py
+++ b/graphviz/backend.py
@@ -4,7 +4,8 @@ import os
 import errno
 import platform
 import subprocess
-import tools
+
+from . import tools
 
 __all__ = ['render', 'pipe', 'view']
 


### PR DESCRIPTION
Importing tools in backend.py introduced an issue around
module vs class importing.  This change switches to relative
import of tools.

fixes xflr6/graphviz#24

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>