### PR TITLE
Ensure test precondition setup.py should exist as a file

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,11 +2,21 @@
 
 import unittest2 as unittest
 import os
+import stat
 
 from graphviz.tools import mkdirs
 
 
 class TestMkdirs(unittest.TestCase):
+    def setUp(self):
+        if not os.path.exists('setup.py'):
+            f = open('setup.py', 'w')
+            f.close()
+
+    def tearDown(self):
+        info = os.stat('setup.py')
+        if info.st_size == 0:
+            os.unlink('setup.py')
 
     @staticmethod
     def _dirnames(path=os.curdir):


### PR DESCRIPTION
Hello,

I building a Debian package for your package, and discovered a problem where one of the tests was failing. It was because the tests were written to assume that they'd be run in the root of the source tree, and not a partially installed copy 
---
As written the tests in test_tools assume the tests will be run in the
root of the source and that a file named setup.py will exist.

The Debian test runner installs the package into a subdirectory,
and then runs the tests there, which lets the test code create a setup.py directory.

This adds a test setUp and tearDown to add (and remove) an empty
setup.py if no setup.py file already exists