### PR TITLE
Add viewer support for FreeBSD

### DIFF
--- a/graphviz/backend.py
+++ b/graphviz/backend.py
@@ -159,6 +159,12 @@ def view_linux(filepath):
     subprocess.Popen(['xdg-open', filepath])
 
 
+@tools.attach(view, 'freebsd')
+def view_freebsd(filepath):
+    """Open filepath in the user's preferred application (freebsd)."""
+    subprocess.Popen(['xdg-open', filepath])
+
+
 @tools.attach(view, 'windows')
 def view_windows(filepath):
     """Start filepath with its associated application (windows)."""

--- a/graphviz/files.py
+++ b/graphviz/files.py
@@ -188,6 +188,7 @@ class File(Base):
 
     _view_darwin = staticmethod(backend.view.darwin)
     _view_linux = staticmethod(backend.view.linux)
+    _view_freebsd = staticmethod(backend.view.freebsd)
     _view_windows = staticmethod(backend.view.windows)
 
 


### PR DESCRIPTION
A call to the `view()` method on FreeBSD would throw a `RuntimeError`. This commit fixes this.