### PR TITLE
add a condition for when python runs with optimization

### DIFF
--- a/graphviz/dot.py
+++ b/graphviz/dot.py
@@ -269,7 +269,8 @@ class Graph(Dot):
 class Digraph(Dot):
     """Directed graph source code in the DOT language."""
 
-    __doc__ += Graph.__doc__.partition('.')[2]
+    if isinstance(Graph.__doc__, str):
+        __doc__ += Graph.__doc__.partition('.')[2]
 
     _head = 'digraph %s{'
     _head_strict = 'strict %s' % _head

--- a/graphviz/dot.py
+++ b/graphviz/dot.py
@@ -269,7 +269,7 @@ class Graph(Dot):
 class Digraph(Dot):
     """Directed graph source code in the DOT language."""
 
-    if isinstance(Graph.__doc__, str):
+    if Graph.__doc__ is not None:
         __doc__ += Graph.__doc__.partition('.')[2]
 
     _head = 'digraph %s{'


### PR DESCRIPTION
i run my code with optimization (python -OO) [1] and see this error:
```python
  File ".../graphviz/__init__.py", line 27, in <module>
    from .dot import Graph, Digraph
  File ".../graphviz/dot.py", line 269, in <module>
    class Digraph(Dot):
  File ".../graphviz/dot.py", line 272, in Digraph
    __doc__ += Graph.__doc__.partition('.')[2]
AttributeError: 'NoneType' object has no attribute 'partition'
```
and after this change the error disappears and my code works

refs:
[1] https://docs.python.org/3/using/cmdline.html#cmdoption-oo