### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,4 @@ Thumbs.db
 
 /test-output/
 
-/examples/*.gv
-/examples/*.pdf
 /examples/.ipynb_checkpoints/


### PR DESCRIPTION
how do people run without gv ? and why don't just show them pdf without asking them to run anyway ?