### PR TITLE
Pass shell=True to Popen on Windows

### DIFF
--- a/graphviz/backend.py
+++ b/graphviz/backend.py
@@ -138,6 +138,8 @@ else:
 
 def run(cmd, input=None, capture_output=False, check=False, quiet=False, **kwargs):
     """Run the command described by cmd and return its (stdout, stderr) tuple."""
+    if PLATFORM == 'windows':  # pragma: no cover
+        kwargs['shell'] = True
     if input is not None:
         kwargs['stdin'] = subprocess.PIPE
     if capture_output:


### PR DESCRIPTION
Required for subprocess to be able to find the `dot.bat` file when calling `dot` (with no extension)