### PR TITLE
Make it work with development version string of the Big Graphviz

### DIFF
--- a/graphviz/backend.py
+++ b/graphviz/backend.py
@@ -260,7 +260,7 @@ def version():
                  stdout=subprocess.PIPE,
                  stderr=subprocess.STDOUT)
 
-    ma = re.search(r'graphviz version (\d+\.\d+(?:\.\d+){,2}) ', out)
+    ma = re.search(r'graphviz version (\d+\.\d+(?:\.\d+){,2})', out)
     if ma is None:
         raise RuntimeError('cannot parse %r output: %r' % (cmd, out))
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -261,6 +261,7 @@ def test_version_parsefail_mocked(mocker, Popen):  # noqa: N803
 @pytest.mark.parametrize('stdout, expected', [
     (b'dot - graphviz version 1.2.3 (mocked)', (1, 2, 3)),
     (b'dot - graphviz version 2.43.20190912.0211 (20190912.0211)\n', (2, 43, 20190912, 211)),
+    (b'dot - graphviz version 2.44.2~dev.20200927.0217 (20200927.0217)\n', (2, 44, 2)),
 ])
 def test_version_mocked(mocker, Popen, stdout, expected):  # noqa: N803
     proc = Popen.return_value


### PR DESCRIPTION
such as:

    $ dot -V
    dot - graphviz version 2.44.2~dev.20200927.0217 (20200927.0217)