### PR TITLE
Inherit render properties

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -453,6 +453,19 @@ Both produce the same result:
     (:ref:`example <cluster.py>`). Also see the `Subgraphs and Clusters`
     section of `the DOT language documentation <DOT_>`_.
 
+Subgraphs support rendering just like Graphs and will inherit the relevant attributes.
+
+.. code:: python
+
+    d = graphviz.Graph(format='svg', encoding='ascii', engine='neato')
+    d.node('1')
+    with d.subgraph(name='cluster_one') as sub:
+        sub.node('2')
+        sub.node('3')
+        sub.edge('2', '3')
+        sub.render()
+    d.edge('1', '2')
+    d.render()
 
 Engines
 -------

--- a/graphviz/dot.py
+++ b/graphviz/dot.py
@@ -67,8 +67,7 @@ class Dot(files.File):
         self.body = list(body) if body is not None else []
 
         self.strict = strict
-        self.enconding=encoding
-        
+        self.enconding = encoding
 
     def _kwargs(self):
         result = super(Dot, self)._kwargs()
@@ -135,7 +134,7 @@ class Dot(files.File):
         self.body.append(line)
 
     def edge(self, tail_name, head_name, label=None, _attributes=None, **attrs):
-        """Create an edge between two nodes. 
+        """Create an edge between two nodes.
 
         Args:
             tail_name: Start node identifier (format: ``node[:port[:compass]]``).
@@ -224,9 +223,9 @@ class Dot(files.File):
                                           'node_attr': node_attr,
                                           'edge_attr': edge_attr,
                                           'body': body,
-                                          'directory':self.directory,
-                                          'engine':self.engine,
-                                          'encoding':self.enconding,
+                                          'directory': self.directory,
+                                          'engine': self.engine,
+                                          'encoding': self.enconding,
                                           'format': self.format})
 
         args = [name, comment, graph_attr, node_attr, edge_attr, body]

--- a/graphviz/dot.py
+++ b/graphviz/dot.py
@@ -67,7 +67,6 @@ class Dot(files.File):
         self.body = list(body) if body is not None else []
 
         self.strict = strict
-        self.enconding = encoding
 
     def _kwargs(self):
         result = super(Dot, self)._kwargs()
@@ -215,6 +214,9 @@ class Dot(files.File):
         Note:
             If the ``name`` of the subgraph begins with ``'cluster'`` (all lowercase)
             the layout engine will treat it as a special cluster subgraph.
+            
+            Instances created are always strict=None for rendering purposes.
+            See https://github.com/xflr6/graphviz/pull/116#issuecomment-706541609
         """
         if graph is None:
             return SubgraphContext(self, {'name': name,
@@ -225,7 +227,7 @@ class Dot(files.File):
                                           'body': body,
                                           'directory': self.directory,
                                           'engine': self.engine,
-                                          'encoding': self.enconding,
+                                          'encoding': self.encoding,
                                           'format': self.format})
 
         args = [name, comment, graph_attr, node_attr, edge_attr, body]

--- a/graphviz/dot.py
+++ b/graphviz/dot.py
@@ -67,6 +67,8 @@ class Dot(files.File):
         self.body = list(body) if body is not None else []
 
         self.strict = strict
+        self.enconding=encoding
+        
 
     def _kwargs(self):
         result = super(Dot, self)._kwargs()
@@ -221,7 +223,11 @@ class Dot(files.File):
                                           'graph_attr': graph_attr,
                                           'node_attr': node_attr,
                                           'edge_attr': edge_attr,
-                                          'body': body})
+                                          'body': body,
+                                          'directory':self.directory,
+                                          'engine':self.engine,
+                                          'encoding':self.enconding,
+                                          'format': self.format})
 
         args = [name, comment, graph_attr, node_attr, edge_attr, body]
         if not all(a is None for a in args):

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -76,11 +76,12 @@ def test_attr_invalid_kw(cls):
 
 def test_inherit_render_properties():
     # non default values
-    d = Graph(format='svg', directory='..')
+    d = Graph(format='svg', directory='..', encoding='ascii', engine='neato' )
     with d.subgraph() as sub:
         assert sub.format == d.format
         assert sub.directory == d.directory
-
+        assert sub.encoding == d.encoding
+        assert sub.engine == d.engine
 
 @pytest.mark.parametrize('cls, expected', [
     (Graph, 'graph {\n\tspam=eggs\n}'),

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -73,13 +73,14 @@ def test_attr_invalid_kw(cls):
     with pytest.raises(ValueError, match=r'attr'):
         cls().attr('spam')
 
+
 def test_inherit_render_properties():
-    #non default values
-    d=Graph(format='svg',directory='..')
+    # non default values
+    d = Graph(format='svg', directory='..')
     with d.subgraph() as sub:
-        assert sub.format==d.format
-        assert sub.directory==d.directory
-        
+        assert sub.format == d.format
+        assert sub.directory == d.directory
+
 
 @pytest.mark.parametrize('cls, expected', [
     (Graph, 'graph {\n\tspam=eggs\n}'),

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -73,6 +73,13 @@ def test_attr_invalid_kw(cls):
     with pytest.raises(ValueError, match=r'attr'):
         cls().attr('spam')
 
+def test_inherit_render_properties():
+    #non default values
+    d=Graph(format='svg',directory='..')
+    with d.subgraph() as sub:
+        assert sub.format==d.format
+        assert sub.directory==d.directory
+        
 
 @pytest.mark.parametrize('cls, expected', [
     (Graph, 'graph {\n\tspam=eggs\n}'),


### PR DESCRIPTION
Hi, 

this is for #114 .

There are two things probably still have to be done: 

I don't know what good non default values would be for 'encoding' and 'engine' for the test function.

There is a check in https://github.com/xflr6/graphviz/blob/master/graphviz/dot.py#L100 that subgraphs can't be strict, so it does not make sense to inherit that one.