### PR TITLE
[MRG] ✨ Add `_repr_html_` method to `graphviz/files.py`

### DIFF
--- a/graphviz/files.py
+++ b/graphviz/files.py
@@ -112,6 +112,9 @@ class File(Base):
     def _repr_svg_(self):
         return self.pipe(format='svg').decode(self._encoding)
 
+    def _repr_html_(self):
+        return "<svg>{0}</svg>".format(self._repr_svg_())
+
     def pipe(self, format=None, renderer=None, formatter=None, quiet=False):
         """Return the source piped through the Graphviz layout command.
 

--- a/graphviz/files.py
+++ b/graphviz/files.py
@@ -112,9 +112,8 @@ class File(Base):
     def _repr_svg_(self):
         return self.pipe(format='svg').decode(self._encoding)
 
-    def _repr_html_(self):
-        return self._repr_svg_()
-
+    _repr_html_ = _repr_svg_
+    
     def pipe(self, format=None, renderer=None, formatter=None, quiet=False):
         """Return the source piped through the Graphviz layout command.
 

--- a/graphviz/files.py
+++ b/graphviz/files.py
@@ -113,7 +113,7 @@ class File(Base):
         return self.pipe(format='svg').decode(self._encoding)
 
     def _repr_html_(self):
-        return "<svg>{0}</svg>".format(self._repr_svg_())
+        return self._repr_svg_()
 
     def pipe(self, format=None, renderer=None, formatter=None, quiet=False):
         """Return the source piped through the Graphviz layout command.

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -38,6 +38,17 @@ def test__repr_svg_(mocker, cls):
     pipe.return_value.decode.assert_called_once_with(c.encoding)
 
 
+def test__repr_html_(mocker, cls):
+    c = cls()
+    kwargs = {'return_value.decode.return_value': mocker.sentinel.decoded}
+    pipe = mocker.patch.object(c, 'pipe', autospec=True, **kwargs)
+
+    assert c._repr_html_() is mocker.sentinel.decoded
+
+    pipe.assert_called_once_with(format='svg')
+    pipe.return_value.decode.assert_called_once_with(c.encoding)
+
+
 @pytest.mark.parametrize('keep_attrs', [False, True])
 def test_clear(cls, keep_attrs):
     kwargs = {'%s_attr' % a: {a: a} for a in ('graph', 'node', 'edge')}

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -69,6 +69,17 @@ def test__repr_svg_(mocker, source):
     pipe.return_value.decode.assert_called_once_with(source.encoding)
 
 
+def test__repr_html_(mocker, source):
+    pipe = mocker.patch.object(source, 'pipe', autospec=True,
+                               **{'return_value.decode.return_value':
+                                  mocker.sentinel.decoded})
+
+    assert source._repr_html_() is mocker.sentinel.decoded
+
+    pipe.assert_called_once_with(format='svg')
+    pipe.return_value.decode.assert_called_once_with(source.encoding)
+
+
 def test_pipe_format(pipe, source, format_='svg'):
     assert source.format != format_
 


### PR DESCRIPTION
Add `_repr_html_` method
Add tests for `_repr_html_` to `test_dot.py` and `test_files.py`

---

This method wraps `_repr_svg_` with the name `_repr_html_` for embedding in html.

The main motivation is for this PR is [`sphinx-gallery`](https://sphinx-gallery.github.io/stable/index.html) support. For example, this lets you automatically embed figures like the figure below.

([Also see this StackOverflow thread where I was trying to figure out how to do this, there are more details there.](https://stackoverflow.com/questions/65008861/capturing-graphviz-figures-in-sphinx-gallery))

![image](https://user-images.githubusercontent.com/11916674/100375139-55dfb680-2fdb-11eb-9ead-8f6c287e3b11.png)

---

I'm less experienced with Jupyter notebooks, but it looks like they work still too:

![image](https://user-images.githubusercontent.com/11916674/100378290-d2c15f00-2fe0-11eb-9e66-0f25287f47ae.png)
