### PR TITLE
Add _repr_mimebundle_ for IPython.display

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog
 Version 0.19 (in development)
 -----------------------------
 
-Replace ``_repr_svg_`` with ``_repr_mimebundle_`` to support svg, png and jpeg.
+Add ``graphviz.set_jupyter_format()`` to set the output format
+used by the jupyter visualization of ``graphviz.Graph``, ``graphviz.Digraph``,
+and ``graphviz.Source`` (supported formats: ``'svg'``, ``'png'``,```'jpeg'``).
+Replace ``_repr_svg_()`` with ``_repr_mimebundle_(include, exclude)``
+returning a mimebundle ``{'image/svg+xml', '<?xml version=...'}`` by default.
 
 
 Version 0.18.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@ Changelog
 =========
 
 
-Version 0.18.3 (in development)
--------------------------------
+Version 0.19 (in development)
+-----------------------------
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 Version 0.19 (in development)
 -----------------------------
 
-
+Replace ``_repr_svg_`` with ``_repr_mimebundle_`` to support svg, png and jpeg.
 
 
 Version 0.18.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = '2013-2021, Sebastian Bank'
 author = 'Sebastian Bank'
 
 # The short X.Y version
-version = '0.18.3.dev0'
+version = '0.19.dev0'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -191,9 +191,14 @@ This also allows direct displaying within the `Jupyter Qt Console`_ (e.g.
 .. image:: _static/qtconsole.png
     :align: center
 
-By default `Jupyter notebook`_ will use SVG for displaying.
-You can use :attr:`~display_svg`, :attr:`~display_png` or
-:attr:`~display_jpeg` from `IPython.display`_ to get a SVG, PNG or JPEG.
+By default ``_repr_mimebundle_()`` will use `'svg'`` format for displaying.
+
+.. hint::
+
+    You can use ``display_svg()``, `display_png``, or ``.display_jpeg``
+    from `IPython.display`_ to display the SVG, PNG or JPEG representation
+    of a :class:`.Graph` or :class:`.Digraph` in a IPython/Jupyter.
+
 
 Styling
 -------

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -179,7 +179,7 @@ Jupyter notebooks
 -----------------
 
 :class:`.Graph` and :class:`.Digraph` objects have a
-:meth:`~.Graph._repr_svg_`-method so they can be rendered and displayed
+:meth:`~.Graph._repr_mimebundle_`-method so they can be rendered and displayed
 directly inside a `Jupyter notebook`_. For an example, check the
 ``examples/graphviz-notebook.ipynb`` file in the
 `source repository/distribution <graphviz-notebook.ipynb_>`_ (or the same
@@ -191,6 +191,9 @@ This also allows direct displaying within the `Jupyter Qt Console`_ (e.g.
 .. image:: _static/qtconsole.png
     :align: center
 
+By default `Jupyter notebook`_ will use SVG for displaying.
+You can use :attr:`~display_svg`, :attr:`~display_png` or
+:attr:`~display_jpeg` from `IPython.display`_ to get a SVG, PNG or JPEG.
 
 Styling
 -------
@@ -707,6 +710,7 @@ cycles.
 .. _unflatten: https://linux.die.net/man/1/unflatten
 .. _unflatten_pdf: https://www.graphviz.org/pdf/unflatten.1.pdf
 .. _Jupyter notebook: https://jupyter.org
+.. _IPython.display: https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html
 .. _graphviz-notebook.ipynb: https://github.com/xflr6/graphviz/blob/master/examples/graphviz-notebook.ipynb
 .. _nbviewer: https://nbviewer.jupyter.org/github/xflr6/graphviz/blob/master/examples/graphviz-notebook.ipynb
 .. _Jupyter Qt Console: https://qtconsole.readthedocs.io

--- a/graphviz/__init__.py
+++ b/graphviz/__init__.py
@@ -42,7 +42,7 @@ __all__ = ['ENGINES', 'FORMATS', 'RENDERERS', 'FORMATTERS',
            'render', 'pipe', 'pipe_string', 'pipe_lines', 'pipe_lines_string',
            'unflatten', 'version', 'view',
            'RequiredArgumentError', 'ExecutableNotFound',
-           'set_default_engine', 'set_default_format']
+           'set_default_engine', 'set_default_format', 'set_jupyter_format']
 
 __title__ = 'graphviz'
 __version__ = '0.19.dev0'
@@ -103,14 +103,15 @@ def set_default_format(format: str) -> str:
     return old_default_format
 
 
-def set_default_jupyter_representation(jupyter_representation: str) -> str:
-    """Change the default jupyter_representation, return the old default value.
-    """
+def set_jupyter_format(jupyter_format: str) -> str:
+    """Change the default mimetype format for ``_repr_mimebundle_(include, exclude)``
+        and return the old value."""
     from . import jupyter_integration
 
-    jupyter_integration.verify_jupyter_representation(jupyter_representation)
+    mimetype = jupyter_integration.get_jupyter_format_mimetype(jupyter_format)
 
-    old = jupyter_integration.JupyterIntegration._jupyter_representation
-    jupyter_integration.JupyterIntegration._jupyter_representation = \
-        jupyter_representation
-    return old
+    old_mimetype = jupyter_integration.JupyterIntegration._jupyter_mimetype
+    old_format = jupyter_integration.get_jupyter_mimetype_format(old_mimetype)
+
+    jupyter_integration.JupyterIntegration._jupyter_mimetype = mimetype
+    return old_format

--- a/graphviz/__init__.py
+++ b/graphviz/__init__.py
@@ -45,7 +45,7 @@ __all__ = ['ENGINES', 'FORMATS', 'RENDERERS', 'FORMATTERS',
            'set_default_engine', 'set_default_format']
 
 __title__ = 'graphviz'
-__version__ = '0.18.3.dev0'
+__version__ = '0.19.dev0'
 __author__ = 'Sebastian Bank <sebastian.bank@uni-leipzig.de>'
 __license__ = 'MIT, see LICENSE.txt'
 __copyright__ = 'Copyright (c) 2013-2021 Sebastian Bank'

--- a/graphviz/__init__.py
+++ b/graphviz/__init__.py
@@ -101,3 +101,16 @@ def set_default_format(format: str) -> str:
     old_default_format = parameters.Parameters._format
     parameters.Parameters._format = format
     return old_default_format
+
+
+def set_default_jupyter_representation(jupyter_representation: str) -> str:
+    """Change the default jupyter_representation, return the old default value.
+    """
+    from . import jupyter_integration
+
+    jupyter_integration.verify_jupyter_representation(jupyter_representation)
+
+    old = jupyter_integration.JupyterIntegration._jupyter_representation
+    jupyter_integration.JupyterIntegration._jupyter_representation = \
+        jupyter_representation
+    return old

--- a/graphviz/graphs.py
+++ b/graphviz/graphs.py
@@ -41,7 +41,7 @@ __all__ = ['Graph', 'Digraph']
 
 class BaseGraph(dot.Dot,
                 rendering.Render,
-                jupyter_integration.JupyterSvgIntegration, piping.Pipe,
+                jupyter_integration.JupyterIntegration, piping.Pipe,
                 unflattening.Unflatten):
     """Dot language creation and source code rendering."""
 

--- a/graphviz/jupyter_integration.py
+++ b/graphviz/jupyter_integration.py
@@ -1,12 +1,86 @@
 """Display rendered graph as SVG in Jupyter Notebooks and QtConsole."""
-
+import typing
 from . import piping
 
-__all__ = ['JupyterSvgIntegration']
+__all__ = ['JUPYTER_REPRESENTATIONS',
+           'verify_jupyter_representation',
+           'JupyterIntegration']
+
+JUPYTER_REPRESENTATIONS = {
+    'image/svg+xml': '_repr_image_svg_xml',
+    'image/png': '_repr_image_png',
+    'image/jpeg': '_repr_image_jpeg',
+
+    # The following does not work yet. Not clear why, because the documentation
+    # has only few information about them.
+    'application/json': None,  # ToDo: What does jupyter expect?
+    'application/pdf': None,  # ToDo: Does Jupyter only accept file path?
+
+    # No reasonable representation
+    'text/plain': None,
+    'text/latex': None,
+    'text/html': None,
+    'application/javascript': None,
+    'text/markdown': None,
+}
+
+DEFAULT_JUPYTER_REPRESENTATION = 'image/svg+xml'
+
+REQUIRED = True
 
 
-class JupyterSvgIntegration(piping.Pipe):
+def verify_jupyter_representation(jupyter_representation: str,
+                                  *,
+                                  required: bool = REQUIRED) -> None:
+    if jupyter_representation is None:
+        if required:
+            raise ValueError('missing jupyter_representation')
+    elif jupyter_representation not in JUPYTER_REPRESENTATIONS:
+        raise ValueError(
+            f'unknown jupyter_representation: {jupyter_representation!r}')
+
+
+class JupyterIntegration(piping.Pipe):
     """Display rendered graph as SVG in Jupyter Notebooks and QtConsole."""
 
-    def _repr_svg_(self):
+    _jupyter_representation = DEFAULT_JUPYTER_REPRESENTATION
+
+    _verify_jupyter_representation = staticmethod(verify_jupyter_representation)
+
+    @property
+    def jupyter_representation(self) -> str:
+        """The output format used for rendering
+            (``'pdf'``, ``'png'``, ...)."""
+        return self._jupyter_representation
+
+    @jupyter_representation.setter
+    def jupyter_representation(self, jupyter_representation: str) -> None:
+        self._verify_jupyter_representation(jupyter_representation)
+        self._jupyter_representation = jupyter_representation
+
+    def _repr_mimebundle_(self,
+                          include: typing.Optional[list] = None,
+                          exclude: typing.Optional[list] = None,
+                          **kwargs) -> dict:
+        # The documentation of this function is in the following notebook:
+        #     "examples/IPython Kernel/Custom Display Logic.ipynb"
+        # https://nbviewer.org/github/ipython/ipython/blob/master/examples/IPython%20Kernel/Custom%20Display%20Logic.ipynb
+        # from IPython git repository. At the moment the readthedocs
+        # documentation of IPython only mention _repr_mimebundle_ but details
+        # are missing.
+        del kwargs
+        reprs = set(include) if include else {self._jupyter_representation}
+        reprs -= exclude or set()
+
+        return {mime: getattr(self, method_name)()
+                for mime, method_name in JUPYTER_REPRESENTATIONS.items()
+                if method_name is not None and mime in reprs}
+
+    def _repr_image_svg_xml(self):
         return self.pipe(format='svg', encoding=self._encoding)
+
+    def _repr_image_png(self):
+        return self.pipe(format='png')
+
+    def _repr_image_jpeg(self):
+        return self.pipe(format='jpeg')

--- a/graphviz/sources.py
+++ b/graphviz/sources.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class Source(rendering.Render, saving.Save,
-             jupyter_integration.JupyterSvgIntegration, piping.Pipe,
+             jupyter_integration.JupyterIntegration, piping.Pipe,
              unflattening.Unflatten):
     """Verbatim DOT source code string to be rendered by Graphviz.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='graphviz',
-    version='0.18.3.dev0',
+    version='0.19.dev0',
     author='Sebastian Bank',
     author_email='sebastian.bank@uni-leipzig.de',
     description='Simple Python interface for Graphviz',

--- a/tests/test_all_classes.py
+++ b/tests/test_all_classes.py
@@ -191,29 +191,26 @@ def test_pipe_lines_mocked(mocker, mock_pipe_lines, dot, format_='svg'):
     assert list(data) == expected_lines
 
 
-def test_repr_svg_mocked(mocker, dot):
+def test_repr_mimebundle_image_svg_xml_mocked(mocker, dot):
     mock_pipe = mocker.patch.object(dot, 'pipe', autospec=True)
 
-    assert dot._repr_mimebundle_({'image/svg+xml'}) == {
-        'image/svg+xml': mock_pipe.return_value}
+    assert dot._repr_mimebundle_({'image/svg+xml'}) == {'image/svg+xml': mock_pipe.return_value}
 
     mock_pipe.assert_called_once_with(format='svg', encoding=dot.encoding)
 
 
-def test_repr_png_mocked(mocker, dot):
+def test_repr_mimebundle_image_png_mocked(mocker, dot):
     mock_pipe = mocker.patch.object(dot, 'pipe', autospec=True)
 
-    assert dot._repr_mimebundle_({'image/png'}) == {
-        'image/png': mock_pipe.return_value}
+    assert dot._repr_mimebundle_({'image/png'}) == {'image/png': mock_pipe.return_value}
 
     mock_pipe.assert_called_once_with(format='png')
 
 
-def test_repr_jpeg_mocked(mocker, dot):
+def test_repr_mimebundle_image_jpeg_mocked(mocker, dot):
     mock_pipe = mocker.patch.object(dot, 'pipe', autospec=True)
 
-    assert dot._repr_mimebundle_({'image/jpeg'}) == {
-        'image/jpeg': mock_pipe.return_value}
+    assert dot._repr_mimebundle_({'image/jpeg'}) == {'image/jpeg': mock_pipe.return_value}
 
     mock_pipe.assert_called_once_with(format='jpeg')
 

--- a/tests/test_all_classes.py
+++ b/tests/test_all_classes.py
@@ -194,9 +194,28 @@ def test_pipe_lines_mocked(mocker, mock_pipe_lines, dot, format_='svg'):
 def test_repr_svg_mocked(mocker, dot):
     mock_pipe = mocker.patch.object(dot, 'pipe', autospec=True)
 
-    assert dot._repr_svg_() is mock_pipe.return_value
+    assert dot._repr_mimebundle_({'image/svg+xml'}) == {
+        'image/svg+xml': mock_pipe.return_value}
 
     mock_pipe.assert_called_once_with(format='svg', encoding=dot.encoding)
+
+
+def test_repr_png_mocked(mocker, dot):
+    mock_pipe = mocker.patch.object(dot, 'pipe', autospec=True)
+
+    assert dot._repr_mimebundle_({'image/png'}) == {
+        'image/png': mock_pipe.return_value}
+
+    mock_pipe.assert_called_once_with(format='png')
+
+
+def test_repr_jpeg_mocked(mocker, dot):
+    mock_pipe = mocker.patch.object(dot, 'pipe', autospec=True)
+
+    assert dot._repr_mimebundle_({'image/jpeg'}) == {
+        'image/jpeg': mock_pipe.return_value}
+
+    mock_pipe.assert_called_once_with(format='jpeg')
 
 
 @pytest.mark.exe

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,8 @@ DEFAULT_ENGINE = 'dot'
 
 DEFAULT_FORMAT = 'pdf'
 
+DEFAULT_JUPYTER_REPRESENTATION = 'image/svg+xml'
+
 
 def test_set_default_engine_invalid():
     with pytest.raises(ValueError, match=r'unknown engine'):
@@ -15,6 +17,11 @@ def test_set_default_engine_invalid():
 def test_set_default_format_invalid():
     with pytest.raises(ValueError, match=r'unknown format'):
         graphviz.set_default_format('nonformat')
+
+
+def test_set_default_jupyter_representation_invalid():
+    with pytest.raises(ValueError, match=r'unknown jupyter_representation'):
+        graphviz.set_default_jupyter_representation('nonformat')
 
 
 def test_set_default_engine(monkeypatch, *, engine='neato', explicit_engine='sfdp'):
@@ -87,3 +94,52 @@ def test_set_default_format(monkeypatch, *, format='png', explicit_format='jpeg'
     assert g2.format == explicit_format
     assert g3.format == DEFAULT_FORMAT
     assert g4.format == explicit_format
+
+
+def test_set_default_jupyter_representation(
+        monkeypatch,
+        *,
+        jupyter_representation='image/png',
+        explicit_jupyter_representation='image/jpeg'):
+    assert len({DEFAULT_JUPYTER_REPRESENTATION,
+                jupyter_representation,
+                explicit_jupyter_representation}) == 3
+
+    from graphviz.jupyter_integration import JupyterIntegration
+    assert JupyterIntegration._jupyter_representation == \
+           DEFAULT_JUPYTER_REPRESENTATION
+    # isolate the test
+    monkeypatch.setattr(
+        'graphviz.jupyter_integration.JupyterIntegration._jupyter_representation',
+        DEFAULT_JUPYTER_REPRESENTATION)
+    assert JupyterIntegration._jupyter_representation == \
+           DEFAULT_JUPYTER_REPRESENTATION
+
+    g1 = graphviz.Graph()
+    assert g1._jupyter_representation == DEFAULT_JUPYTER_REPRESENTATION
+
+    g2 = graphviz.Graph()
+    g2.jupyter_representation = explicit_jupyter_representation
+    assert g2.jupyter_representation == explicit_jupyter_representation
+
+    old = graphviz.set_default_jupyter_representation(jupyter_representation)
+    assert old == DEFAULT_JUPYTER_REPRESENTATION
+
+    assert g1.jupyter_representation == jupyter_representation
+    assert g2.jupyter_representation == explicit_jupyter_representation
+
+    g3 = graphviz.Graph()
+    assert g3.jupyter_representation == jupyter_representation
+
+    g4 = graphviz.Graph()
+    g4.jupyter_representation = explicit_jupyter_representation
+    assert g4.jupyter_representation == explicit_jupyter_representation
+
+    old = graphviz.set_default_jupyter_representation(
+        DEFAULT_JUPYTER_REPRESENTATION)
+    assert old == jupyter_representation
+
+    assert g1.jupyter_representation == DEFAULT_JUPYTER_REPRESENTATION
+    assert g2.jupyter_representation == explicit_jupyter_representation
+    assert g3.jupyter_representation == DEFAULT_JUPYTER_REPRESENTATION
+    assert g4.jupyter_representation == explicit_jupyter_representation

--- a/tests/test_jupyter_integration.py
+++ b/tests/test_jupyter_integration.py
@@ -1,0 +1,18 @@
+import pytest
+
+from graphviz import jupyter_integration
+
+
+def test_get_jupyter_format_mimetype_invalid_raises_unknown():
+    with pytest.raises(ValueError, match=r'unknown'):
+        jupyter_integration.get_jupyter_format_mimetype('Brian!')
+
+
+def test_get_jupyter_mimetype_format_normalizes():
+    assert jupyter_integration.get_jupyter_mimetype_format(
+        jupyter_integration.get_jupyter_format_mimetype('jpg')) == 'jpeg'
+
+
+def test_get_jupyter_mimetype_format_raises_unsupported():
+    with pytest.raises(ValueError, match='unsupported'):
+        jupyter_integration.get_jupyter_mimetype_format('A boy called Brian!')

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -2,11 +2,13 @@ import pytest
 
 import graphviz
 from graphviz import parameters
+from graphviz import jupyter_integration
 
 VERIFY_FUNCS = [parameters.verify_engine,
                 parameters.verify_format,
                 parameters.verify_renderer,
-                parameters.verify_formatter]
+                parameters.verify_formatter,
+                jupyter_integration.verify_jupyter_representation]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -2,13 +2,11 @@ import pytest
 
 import graphviz
 from graphviz import parameters
-from graphviz import jupyter_integration
 
 VERIFY_FUNCS = [parameters.verify_engine,
                 parameters.verify_format,
                 parameters.verify_renderer,
-                parameters.verify_formatter,
-                jupyter_integration.verify_jupyter_representation]
+                parameters.verify_formatter]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Address #138

@xflr6 Thank you for the modifications of the graphviz code base.
I followed your suggestion and implemented the `_repr_mimebundle_ `.
For SVG, PNG and JPEG it works, but PDF and JSON didn't work.
In the IPython documentation is not much info, so I was not able to figure out, why they don't work.
(For PDF, they may expect a file)

I didn't change the name for `JupyterSvgIntegration`, because I wanted to wait for feedback.

