### PR TITLE
Drop mock_use_standalone_module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ addopts =
   --durations=10
   --cov --cov-report=term --cov-report=html
   --strict-config --strict-markers
-mock_use_standalone_module = true
 log_cli = true
 log_cli_level = WARNING
 log_file = test-log.txt

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     extras_require={
         'dev': ['tox>=3', 'flake8', 'pep8-naming', 'wheel', 'twine'],
         'test': ['pytest>=6',
-                 'pytest-mock>=3', 'mock>=4',
+                 'pytest-mock>=3',
                  'pytest-cov', 'coverage'],
         'docs': ['sphinx>=1.8', 'sphinx-autodoc-typehints', 'sphinx-rtd-theme'],
     },


### PR DESCRIPTION
Mock is integrated to Python as unittest.mock since version 3.6 so importing mock is no longer necessary.

See https://github.com/testing-cabal/mock/blob/master/README.rst
and https://github.com/pytest-dev/pytest-mock/blob/main/src/pytest_mock/_util.py#L17