### PR TITLE
Not pure Python, needs GraphViz installed

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ------------
 
-:doc:`graphviz <api>` provides a simple pure-Python interface for the Graphviz_
+:doc:`graphviz <api>` provides a simple Python interface for the Graphviz_
 graph-drawing software. It runs under Python 3.7+. To install it with pip_, run
 the following:
 


### PR DESCRIPTION
I am not sure if GraphViz is only needed for rendering, but pure Python packages are those that do not require any binary dependencies except Python itself.