### PR TITLE
fix(rendering): 'Path' has no attribute 'endswith'

### DIFF
--- a/graphviz/backend/rendering.py
+++ b/graphviz/backend/rendering.py
@@ -322,7 +322,7 @@ def render(engine: str,
     cmd += args
 
     execute.run_check(cmd,
-                      cwd=filepath.parent if filepath.parent.parts else None,
+                      cwd=str(filepath.parent) if filepath.parent.parts else None,
                       quiet=quiet,
                       capture_output=True)
 


### PR DESCRIPTION
Fix the error when rendering that says 'Path' has no attribute 'endswith'. Making string the object no problem is given.