### PR TITLE
Add _repr_html_ method

### DIFF
--- a/docs/jupyter_notebooks.rst
+++ b/docs/jupyter_notebooks.rst
@@ -27,5 +27,7 @@ that is used for displaying in IPython/Jupyter.
     :class:`.Graph` or :class:`.Digraph` as SVG, PNG or JPEG
     in IPython/Jupyter.
 
+They also have a `_repr_html_` method that returns the SVG description, which is
+valid HTML. This is used by, e.g., sphinx-gallery to directly display the graph.
 
 .. include:: _links.rst

--- a/graphviz/jupyter_integration.py
+++ b/graphviz/jupyter_integration.py
@@ -110,3 +110,5 @@ class JupyterIntegration(piping.Pipe):
     def _repr_image_svg_xml(self) -> str:
         """Return the rendered graph as SVG string."""
         return self.pipe(format='svg', encoding=SVG_ENCODING)
+
+    _repr_html_ = _repr_image_svg_xml

--- a/tests/test_jupyter_integration.py
+++ b/tests/test_jupyter_integration.py
@@ -58,3 +58,10 @@ def test_repr_image_svg_xml_encoding_mocked(mocker, mock_pipe_lines_string,
         assert 'encoding' not in mock_pipe_lines.call_args.kwargs
         (mock_pipe_lines.return_value.decode
          .assert_called_once_with(EXPECTED_SVG_ENCODING))
+
+
+@pytest.mark.exe
+def test_repr_html_gives_svg_xml():
+    dot = graphviz.Graph()
+
+    assert dot._repr_html_() == dot._repr_image_svg_xml()


### PR DESCRIPTION
Closes #199 

This adds a `_repr_html_` method to `Graph` and `Digraph`. This is useful for displaying graphs directly in e.g. sphinx-gallery. The method is simply the SVG generation as SVG is valid HTML.

I *think* that Jupyter first looks at `_repr_mimebundle_`, so it shouldn't affect that.