### PR TITLE
Fix typo 'raise_if_result_exits' in render() argument name

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -504,7 +504,7 @@ https://github.com/xflr6/graphviz/blob/master/docs/api.rst#graph-1
      |          outfile: Path for the rendered output file.
      |          engine: Layout engine for rendering
      |              (``'dot'``, ``'neato'``, ...).
-     |          raise_if_result_exits: Raise :exc:`graphviz.FileExistsError`
+     |          raise_if_result_exists: Raise :exc:`graphviz.FileExistsError`
      |              if the result file exists.
      |          overwrite_source: Allow ``dot`` to write to the file it reads from.
      |              Incompatible with ``raise_if_result_exists``.
@@ -1016,7 +1016,7 @@ https://github.com/xflr6/graphviz/blob/master/docs/api.rst#digraph-1
      |          outfile: Path for the rendered output file.
      |          engine: Layout engine for rendering
      |              (``'dot'``, ``'neato'``, ...).
-     |          raise_if_result_exits: Raise :exc:`graphviz.FileExistsError`
+     |          raise_if_result_exists: Raise :exc:`graphviz.FileExistsError`
      |              if the result file exists.
      |          overwrite_source: Allow ``dot`` to write to the file it reads from.
      |              Incompatible with ``raise_if_result_exists``.
@@ -1425,7 +1425,7 @@ https://github.com/xflr6/graphviz/blob/master/docs/api.rst#source-1
      |          outfile: Path for the rendered output file.
      |          engine: Layout engine for rendering
      |              (``'dot'``, ``'neato'``, ...).
-     |          raise_if_result_exits: Raise :exc:`graphviz.FileExistsError`
+     |          raise_if_result_exists: Raise :exc:`graphviz.FileExistsError`
      |              if the result file exists.
      |          overwrite_source: Allow ``dot`` to write to the file it reads from.
      |              Incompatible with ``raise_if_result_exists``.

--- a/graphviz/backend/rendering.py
+++ b/graphviz/backend/rendering.py
@@ -222,7 +222,7 @@ def render(engine: str,
         neato_no_op: Neato layout engine no-op flag.
         quiet: Suppress ``stderr`` output from the layout subprocess.
         outfile: Path for the rendered output file.
-        raise_if_result_exits: Raise :exc:`graphviz.FileExistsError`
+        raise_if_result_exists: Raise :exc:`graphviz.FileExistsError`
             if the result file exists.
         overwrite_filepath: Allow ``dot`` to write to the file it reads from.
             Incompatible with ``raise_if_result_exists``.

--- a/graphviz/rendering.py
+++ b/graphviz/rendering.py
@@ -59,7 +59,7 @@ class Render(saving.Save, backend.Render, backend.View):
             outfile: Path for the rendered output file.
             engine: Layout engine for rendering
                 (``'dot'``, ``'neato'``, ...).
-            raise_if_result_exits: Raise :exc:`graphviz.FileExistsError`
+            raise_if_result_exists: Raise :exc:`graphviz.FileExistsError`
                 if the result file exists.
             overwrite_source: Allow ``dot`` to write to the file it reads from.
                 Incompatible with ``raise_if_result_exists``.


### PR DESCRIPTION
Fixes typo in kwarg