### PR TITLE
migrate from external mock package to stdlib unittest.mock

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ testpaths =
   graphviz
   tests
 addopts =
-  --doctest-modules 
+  --doctest-modules
   --doctest-glob='*.rst' --ignore=docs/conf.py
   --doctest-continue-on-failure
   # pytest summary: all except (E)rror
@@ -24,7 +24,6 @@ addopts =
   --durations=10
   --cov --cov-report=term --cov-report=html
   --strict-config --strict-markers
-mock_use_standalone_module = true
 log_cli = true
 log_cli_level = WARNING
 log_file = test-log.txt

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     extras_require={
         'dev': ['tox>=3', 'flake8', 'pep8-naming', 'wheel', 'twine'],
         'test': ['pytest>=7',
-                 'pytest-mock>=3', 'mock>=4',
+                 'pytest-mock>=3',
                  'pytest-cov', 'coverage'],
         'docs': ['sphinx>=5,<7', 'sphinx-autodoc-typehints', 'sphinx-rtd-theme'],
     },


### PR DESCRIPTION
The PyPI standalone mock package is a straight backport of the stdlib to older versions of python. It is usually not needed.

In this case, the required version of mock is >=4, which backports the python 3.8 stdlib. The minimum version of python required is already 3.8, so all functionality guaranteed to exist is already part of the stdlib.

Simply use the stdlib directly.