### PR TITLE
Add `svg_inline` to formats.py

### DIFF
--- a/graphviz/parameters/formats.py
+++ b/graphviz/parameters/formats.py
@@ -33,7 +33,7 @@ FORMATS = {'bmp',  # https://graphviz.org/docs/outputs/
            'ps2',
            'psd',
            'sgi',
-           'svg', 'svgz',
+           'svg', 'svgz', 'svg_inline',
            'tga',
            'tif', 'tiff',
            'tk',


### PR DESCRIPTION
Closes #233.

From the [GraphViz](https://graphviz.org/docs/outputs/svg/) docs:

> `svg_inline`, available since Graphviz 10.0.1, produces header-less SVG suitable for inlining into HTML.

This works perfectly for me locally - the `svg_inline` has neither the XML declaration nor the namespace:

```python
In [8]: print(graphviz.pipe_string("dot", "svg", "graph { spam }", encoding="utf-8"))
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
 "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<!-- Generated by graphviz version 12.2.1 (20241206.2353)
 -->
<!-- Pages: 1 -->
<svg width="70pt" height="44pt"
 viewBox="0.00 0.00 69.76 44.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 40)">
<polygon fill="white" stroke="none" points="-4,4 -4,-40 65.76,-40 65.76,4 -4,4"/>
<!-- spam -->
<g id="node1" class="node">
<title>spam</title>
<ellipse fill="none" stroke="black" cx="30.88" cy="-18" rx="30.88" ry="18"/>
<text text-anchor="middle" x="30.88" y="-12.95" font-family="Times,serif" font-size="14.00">spam</text>
</g>
</g>
</svg>


In [9]: print(graphviz.pipe_string("dot", "svg_inline", "graph { spam }", encoding="utf-8"))
<!-- Generated by graphviz version 12.2.1 (20241206.2353)
 -->
<!-- Pages: 1 -->
<svg width="70pt" height="44pt"
 viewBox="0.00 0.00 69.76 44.00">
<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 40)">
<polygon fill="white" stroke="none" points="-4,4 -4,-40 65.76,-40 65.76,4 -4,4"/>
<!-- spam -->
<g id="node1" class="node">
<title>spam</title>
<ellipse fill="none" stroke="black" cx="30.88" cy="-18" rx="30.88" ry="18"/>
<text text-anchor="middle" x="30.88" y="-12.95" font-family="Times,serif" font-size="14.00">spam</text>
</g>
</g>
</svg>