### PR TITLE
fix tests on Python 3.14

### DIFF
--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -17,7 +17,7 @@ def test_deprecated_escape(recwarn, char):
     assert len(recwarn) == 1
     w = recwarn.pop(DeprecationWarning if sys.version_info < (3, 12)
                     else SyntaxWarning)
-    assert str(w.message).startswith('invalid escape sequence')
+    assert 'invalid escape sequence' in str(w.message)
 
     assert escape == f'\\{char}'
     assert quoting.quote(escape) == f'"\\{char}"'


### PR DESCRIPTION
Python 3.14 changed its error formating. With this change the tests run just fine on Python 3.14.0rc2.