### PR TITLE
fix: infer_format fails for xdot1.2 and xdot1.4 outfile names

### DIFF
--- a/graphviz/backend/rendering.py
+++ b/graphviz/backend/rendering.py
@@ -97,6 +97,12 @@ def infer_format(outfile: pathlib.Path) -> str:
     >>> infer_format(pathlib.Path('spam.PNG'))
     'png'
 
+    >>> infer_format(pathlib.Path('spam.xdot1.2'))
+    'xdot1.2'
+
+    >>> infer_format(pathlib.Path('spam.xdot1.4'))
+    'xdot1.4'
+
     >>> infer_format(pathlib.Path('spam'))
     Traceback (most recent call last):
         ...
@@ -119,6 +125,13 @@ def infer_format(outfile: pathlib.Path) -> str:
     try:
         parameters.verify_format(format_)
     except ValueError:
+        # Fall back to matching the file name against formats that contain dots
+        # (e.g. 'xdot1.2', 'xdot1.4'), since pathlib.Path.suffix only returns
+        # the last component and cannot represent a multi-dot format extension.
+        name_lower = outfile.name.lower()
+        for fmt in sorted(parameters.FORMATS, key=len, reverse=True):
+            if '.' in fmt and name_lower.endswith('.' + fmt):
+                return fmt
         raise ValueError('cannot infer rendering format'
                          f' from suffix {outfile.suffix!r}'
                          f' of outfile: {os.fspath(outfile)!r}'

--- a/tests/backend/test_rendering.py
+++ b/tests/backend/test_rendering.py
@@ -195,7 +195,10 @@ def test_get_filepath(outfile, expected_fspath):
      ('spam.jpeg', None, 'jpeg'),
      ('spam.SVG', None, 'svg'),
      ('spam.pdf', None, 'pdf'),
-     ('spam.pdf', 'pdf', 'pdf')])
+     ('spam.pdf', 'pdf', 'pdf'),
+     ('spam.xdot1.2', None, 'xdot1.2'),
+     ('spam.xdot1.4', None, 'xdot1.4'),
+     ('spam.XDOT1.2', None, 'xdot1.2')])
 def test_get_format(outfile_name, format, expected_result):
     outfile = pathlib.Path(outfile_name)
 


### PR DESCRIPTION
## Bug

`infer_format` cannot detect the `xdot1.2` or `xdot1.4` rendering formats
when they appear as file extensions, because `pathlib.Path.suffix` only
returns the last component after the final dot:

```python
>>> import pathlib
>>> pathlib.Path('output.xdot1.2').suffix
'.2'
```

Both formats are listed in `FORMATS` and appear in `get_supported_suffixes()`,
but calling `render(outfile='graph.xdot1.2')` (without an explicit `format=`)
raises:

```
ValueError: cannot infer rendering format from suffix '.2' of outfile: 'graph.xdot1.2'
(unknown format: '2', provide outfile with a suffix from [..., '.xdot1.2', '.xdot1.4', ...])
```

The error message even lists `.xdot1.2` and `.xdot1.4` as valid choices,
making the failure message doubly confusing.

## Fix

When the single-component suffix check fails, fall back to scanning all
`FORMATS` that contain a literal dot (there are exactly two: `xdot1.2` and
`xdot1.4`) and check whether the outfile name ends with `'.' + format`.
This is cheap (two candidates) and correct for any future formats of the
same shape.

## Tests

Three new parametrised cases in `test_get_format`:
- `spam.xdot1.2` → `'xdot1.2'`
- `spam.xdot1.4` → `'xdot1.4'`
- `spam.XDOT1.2` → `'xdot1.2'` (case-normalisation)

Two new doctests in `infer_format` covering the same inputs.

All existing tests continue to pass.

---

This pull request was prepared with the assistance of AI, under my direction and review.