### PR TITLE
fix broken infer_format() with `.xdot1.2` and `.xdot1.4` path suffixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Drop Pyton 3.9 support (end of life 2025-10).
 
 Tag Python 3.14 support.
 
+Fix broken ``format`` inference for dotted format suffixes ``.xdot1.2`` and
+``.xdot1.4`` (aliases for ``.dot``).
+
 Improve type annotations, switch type checking from
 https://github.com/google/pytype to https://mypy-lang.org, and mark package
 as `py.typed` (PEP 561 compliant).

--- a/graphviz/backend/rendering.py
+++ b/graphviz/backend/rendering.py
@@ -15,6 +15,9 @@ from . import execute
 
 __all__ = ['get_format', 'get_filepath', 'render']
 
+DOUBLE_SUFFIXES = {f'.{fmt}' for fmt in parameters.FORMATS
+                   if fmt in ('xdot1.2', 'xdot1.4')}
+
 
 def get_format(outfile: pathlib.Path, *, format: str | None) -> str:
     """Return format inferred from outfile suffix and/or given ``format``.
@@ -111,6 +114,9 @@ def infer_format(outfile: pathlib.Path) -> str:
     if not outfile.suffix:
         raise ValueError('cannot infer rendering format from outfile:'
                          f' {os.fspath(outfile)!r} (missing suffix)')
+
+    if (double_sfx := ''.join(outfile.suffixes[-2:]).lower()) in DOUBLE_SUFFIXES:
+        return double_sfx.removeprefix('.')
 
     (start, sep, format_) = outfile.suffix.partition('.')
     assert sep and not start, f"{outfile.suffix!r}.startswith('.')"

--- a/tests/backend/test_rendering.py
+++ b/tests/backend/test_rendering.py
@@ -195,7 +195,10 @@ def test_get_filepath(outfile, expected_fspath):
      ('spam.jpeg', None, 'jpeg'),
      ('spam.SVG', None, 'svg'),
      ('spam.pdf', None, 'pdf'),
-     ('spam.pdf', 'pdf', 'pdf')])
+     ('spam.pdf', 'pdf', 'pdf'),
+     ('spam.xdot1.2', None, 'xdot1.2'),
+     ('spam.XDOT1.2', None, 'xdot1.2'),
+     ('spam.xdot1.4', None, 'xdot1.4')])
 def test_get_format(outfile_name, format, expected_result):
     outfile = pathlib.Path(outfile_name)
 


### PR DESCRIPTION
- supersedes #243